### PR TITLE
chore: Rename the `startWatchingTransitions` method to `enableRouteValidation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Next, edit the `application` route from step 1 as follows:
 
 1. Use the [`setRoutePermissions`](#setroutepermissions) method to pass along the required permissions per route to the `permissions` service.
 2. Handle the [`route-access-denied`](#route-access-denied) event to determine what to do when a transition is denied.
-3. Call [`startWatchingTransitions`](#startwatchingtransitions) to enable route validation.
+3. Call [`enableRouteValidation`](#enableroutevalidation).
 
 ```javascript
 // app/routes/application.js
@@ -114,7 +114,7 @@ export default Route.extend({
       this.replaceWith('error', { error: 'route-access-denied' });
     });
 
-    this.permissionsService.startWatchingTransitions();
+    this.permissionsService.enableRouteValidation();
   }
 });
 ```
@@ -235,9 +235,9 @@ Returns `true` if the provided route can be accessed, `false` if otherwise.
 permissionsService.canAccessRoute('users.index');
 ```
 
-##### startWatchingTransitions
+##### enableRouteValidation
 
-Allows you to manually start watching transitions. "Watching transitions" means that the service will validate each transition and see if it's allowed based on the required permissions per route. If a transition is not allowed the [`route-access-denied`](#route-access-denied) event will be triggered.
+This will tell the service that it should start validating each transition and confirm that it's allowed based on the required permissions per route. If a transition is not allowed the [`route-access-denied`](#route-access-denied) event will be triggered.
 
 ###### Arguments
 
@@ -250,7 +250,7 @@ Allows you to manually start watching transitions. "Watching transitions" means 
 ###### Example
 
 ```javascript
-permissionsService.startWatchingTransitions();
+permissionsService.enableRouteValidation();
 ```
 
 #### Events

--- a/addon/services/permissions.js
+++ b/addon/services/permissions.js
@@ -13,7 +13,7 @@ export default Service.extend(Evented, {
    */
 
   initialTransition: null,
-  isWatchingTransitions: false,
+  isRouteValidationEnabled: false,
   permissions: null,
   routePermissions: null,
 
@@ -83,14 +83,14 @@ export default Service.extend(Evented, {
     return routeTreePermissions;
   },
 
-  startWatchingTransitions() {
-    if (this.isWatchingTransitions) {
+  enableRouteValidation() {
+    if (this.isRouteValidationEnabled) {
       return;
     }
 
-    this.set('isWatchingTransitions', true);
+    this.set('isRouteValidationEnabled', true);
 
-    // Validate the initial transition if `startWatchingTransitions` was called during.
+    // Validate the initial transition if `enableRouteValidation` was called during it.
     if (this.initialTransition && !this.canAccessRoute(this.initialTransition.to.name)) {
       this.trigger('route-access-denied', this.initialTransition);
     }


### PR DESCRIPTION
This makes it more clear why the function needs to be called since it now describes what it is doing instead of how it is doing it.

BREAKING CHANGE: `startWatchingTransitions` is changed to `enableRouteValidation`
Fixes #2 