### PR TITLE
fix: Call cacheInitialTransition during initialization

### DIFF
--- a/addon/instance-initializers/ember-permissions.js
+++ b/addon/instance-initializers/ember-permissions.js
@@ -1,0 +1,9 @@
+export function initialize (applicationInstance) {
+  let permissionsService = applicationInstance.lookup('service:permissions')
+
+  permissionsService.cacheInitialTransition()
+}
+
+export default {
+  initialize
+}

--- a/addon/services/permissions.js
+++ b/addon/services/permissions.js
@@ -27,7 +27,6 @@ export default Service.extend(Evented, {
 
     this.setPermissions([])
     this.setRoutePermissions({})
-    this.cacheInitialTransition()
   },
 
   /**

--- a/app/instance-initializers/ember-permissions.js
+++ b/app/instance-initializers/ember-permissions.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize
+} from '@bagaar/ember-permissions/instance-initializers/ember-permissions'

--- a/tests/unit/instance-initializers/ember-permissions-test.js
+++ b/tests/unit/instance-initializers/ember-permissions-test.js
@@ -1,0 +1,31 @@
+import Application from '@ember/application'
+
+import { initialize } from 'dummy/instance-initializers/ember-permissions'
+import { module, test } from 'qunit'
+import { run } from '@ember/runloop'
+
+import PermissionsService from '@bagaar/ember-permissions/services/permissions'
+
+module('Unit | Instance Initializer | ember-permissions', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = Application.extend()
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize
+    })
+    this.application = this.TestApplication.create({ autoboot: false })
+    this.instance = this.application.buildInstance()
+  })
+  hooks.afterEach(function () {
+    run(this.application, 'destroy')
+    run(this.instance, 'destroy')
+  })
+
+  test('it works', async function (assert) {
+    this.instance.register('service:permissions', PermissionsService)
+
+    await this.instance.boot()
+
+    assert.ok(true)
+  })
+})


### PR DESCRIPTION
This makes sure we always have a reference to the initial transition when calling enableRouteValidation in order to validate it.