### PR TITLE
Don't assume `transition.to` is always present when validating transitions

### DIFF
--- a/addon/services/permissions.js
+++ b/addon/services/permissions.js
@@ -109,7 +109,9 @@ export default class PermissionsService extends Service {
 
   @action
   validateTransition(transition) {
-    if (transition && this.canAccessRoute(transition.to.name) === false) {
+    const routeName = transition?.to?.name;
+
+    if (routeName && this.canAccessRoute(routeName) === false) {
       this.trigger('route-access-denied', transition);
     }
   }

--- a/tests/unit/services/permissions-test.js
+++ b/tests/unit/services/permissions-test.js
@@ -124,4 +124,31 @@ module('Unit | Service | permissions', function (hooks) {
       );
     });
   });
+
+  module('validateTransition', function () {
+    test('it works', function (assert) {
+      const permissionsService = this.owner.lookup('service:permissions');
+
+      let timesCalled = 0;
+
+      function handler() {
+        timesCalled += 1;
+      }
+
+      permissionsService.setRoutePermissions({
+        [ROUTE.FOO]: [PERMISSION.FOO],
+      });
+
+      permissionsService.on('route-access-denied', handler);
+
+      permissionsService.validateTransition();
+      permissionsService.validateTransition({});
+      permissionsService.validateTransition({ to: {} });
+      permissionsService.validateTransition({ to: { name: ROUTE.FOO } });
+
+      permissionsService.off('route-access-denied', handler);
+
+      assert.strictEqual(timesCalled, 1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #86.