### PR TITLE
Add new `addRouteAccessDeniedHandler` and `removeRouteAccessDeniedHandler` service methods

### DIFF
--- a/tests/acceptance/route-validation-test.ts
+++ b/tests/acceptance/route-validation-test.ts
@@ -13,7 +13,7 @@ import { module, test } from 'qunit';
 module('Acceptance | route validation', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('it only triggers the `route-access-denied` event when `enableRouteValidation` was called', async function (assert) {
+  test('it only calls route-access-denied handlers when route validation is enabled', async function (assert) {
     const permissionsService = this.owner.lookup(
       'service:permissions'
     ) as PermissionsService;
@@ -28,7 +28,7 @@ module('Acceptance | route validation', function (hooks) {
     const handler = (deniedTransition: Transition) =>
       (deniedTransitionToName = deniedTransition.to.name);
 
-    permissionsService.on('route-access-denied', handler);
+    permissionsService.addRouteAccessDeniedHandler(handler);
 
     permissionsService.setRoutePermissions({
       [ROUTE.FOO]: [PERMISSION.FOO],
@@ -50,7 +50,7 @@ module('Acceptance | route validation', function (hooks) {
     await visit(ROUTE.FOO);
     assert.strictEqual(deniedTransitionToName, ROUTE.FOO);
 
-    permissionsService.off('route-access-denied', handler);
+    permissionsService.removeRouteAccessDeniedHandler(handler);
   });
 
   test('it validates the initial transition', async function (assert) {
@@ -72,10 +72,10 @@ module('Acceptance | route validation', function (hooks) {
           this.routerService.replaceWith('access-denied');
         };
 
-        this.permissionsService.on('route-access-denied', handler);
+        this.permissionsService.addRouteAccessDeniedHandler(handler);
 
         registerDestructor(this, () => {
-          this.permissionsService.off('route-access-denied', handler);
+          this.permissionsService.removeRouteAccessDeniedHandler(handler);
         });
 
         this.permissionsService.enableRouteValidation(transition);

--- a/tests/unit/services/permissions-test.ts
+++ b/tests/unit/services/permissions-test.ts
@@ -139,7 +139,7 @@ module('Unit | Service | permissions', function (hooks) {
         [ROUTE.FOO]: [PERMISSION.FOO],
       });
 
-      this.permissionsService.on('route-access-denied', handler);
+      this.permissionsService.addRouteAccessDeniedHandler(handler);
 
       // @ts-expect-error: Testing runtime validation.
       this.permissionsService.validateTransition();
@@ -150,7 +150,7 @@ module('Unit | Service | permissions', function (hooks) {
       // @ts-expect-error: Mock `RouteInfo`.
       this.permissionsService.validateTransition({ to: { name: ROUTE.FOO } });
 
-      this.permissionsService.off('route-access-denied', handler);
+      this.permissionsService.removeRouteAccessDeniedHandler(handler);
 
       assert.strictEqual(timesCalled, 1);
     });


### PR DESCRIPTION
In favor of the `on` and `off` methods.
The `on` and `off` methods are too generic and this addon doesn't need to support triggering multiple events.

Before:

```js
const handler = () => {};

this.permissionsService.on('route-access-denied', handler);
this.permissionsService.off('route-access-denied', handler);
```

After:

```js
const handler = () => {};

this.permissionsService.addRouteAccessDeniedHandler(handler);
this.permissionsService.removeRouteAccessDeniedHandler(handler);
```