### PR TITLE
Add support for checking if some of the provided permissions are available for the current session

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Permission management for Ember applications.
     - [`setPermissions`](#setpermissions)
     - [`setRoutePermissions`](#setroutepermissions)
     - [`hasPermissions`](#haspermissions)
+    - [`hasSomePermissions`](#hassomepermissions)
     - [`canAccessRoute`](#canaccessroute)
     - [`enableRouteValidation`](#enableroutevalidation)
     - [`addRouteAccessDeniedHandler`](#addrouteaccessdeniedhandler)
     - [`removeRouteAccessDeniedHandler`](#removerouteaccessdeniedhandler)
   - [Helpers](#helpers)
     - [`has-permissions`](#has-permissions)
+    - [`has-some-permissions`](#has-some-permissions)
     - [`can-access-route`](#can-access-route)
 - [Contributing](#contributing)
 - [License](#license)
@@ -81,7 +83,7 @@ Once the permissions are set, we can start checking their presence. In the examp
 {{/if}}
 ```
 
-> **NOTE:** If you need to validate permissions inside a JavaScript file, you can use the [`hasPermissions`](#haspermissions) method on the `permissions` service instead.
+> **NOTE:** If you need to validate permissions inside a JavaScript file, you can use the [`hasPermissions`](#haspermissions) or the [`hasSomePermissions`](#hassomepermissions) method on the `permissions` service instead.
 
 ### 2\. Setting up Route Permissions
 
@@ -229,6 +231,28 @@ permissionsService.hasPermissions([
 ]);
 ```
 
+##### `hasSomePermissions`
+
+Check if some of the provided permissions are available for the current session.
+
+###### Arguments
+
+An array of permissions.
+
+###### Returns
+
+Returns `true` if some of the provided permissions are available for the current session, `false` if otherwise.
+
+###### Example
+
+```javascript
+permissionsService.hasSomePermissions([
+  'view-users',
+  'create-users',
+  'edit-users',
+]);
+```
+
 ##### `canAccessRoute`
 
 Check if the provided route can be accessed.
@@ -331,6 +355,24 @@ Returns `true` if all the provided permissions are available for the current ses
 
 ```handlebars
 {{has-permissions "view-users" "create-users" "edit-users"}}
+```
+
+#### `has-some-permissions`
+
+Check if some of the provided permissions are available for the current session.
+
+###### Arguments
+
+Separate permissions.
+
+###### Returns
+
+Returns `true` if some of the provided permissions are available for the current session, `false` if otherwise.
+
+###### Example
+
+```handlebars
+{{has-some-permissions "view-users" "create-users" "edit-users"}}
 ```
 
 #### `can-access-route`

--- a/addon/helpers/has-some-permissions.ts
+++ b/addon/helpers/has-some-permissions.ts
@@ -1,0 +1,12 @@
+import type PermissionsService from '@bagaar/ember-permissions/services/permissions';
+import type { Permissions } from '@bagaar/ember-permissions/services/permissions';
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default class HasSomePermissionsHelper extends Helper {
+  @service('permissions') declare permissionsService: PermissionsService;
+
+  compute(permissions: Permissions) {
+    return this.permissionsService.hasSomePermissions(permissions);
+  }
+}

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,0 +1,16 @@
+import type {
+  CanAccessRouteHandler,
+  Permissions,
+} from '@bagaar/ember-permissions/services/permissions';
+
+export function hasPermissions(
+  permissions: Permissions
+): CanAccessRouteHandler {
+  return (service) => service.hasPermissions(permissions);
+}
+
+export function hasSomePermissions(
+  permissions: Permissions
+): CanAccessRouteHandler {
+  return (service) => service.hasSomePermissions(permissions);
+}

--- a/app/helpers/has-some-permissions.js
+++ b/app/helpers/has-some-permissions.js
@@ -1,0 +1,1 @@
+export { default } from '@bagaar/ember-permissions/helpers/has-some-permissions';

--- a/tests/integration/helpers/has-some-permissions-test.ts
+++ b/tests/integration/helpers/has-some-permissions-test.ts
@@ -1,0 +1,36 @@
+import type PermissionsService from '@bagaar/ember-permissions/services/permissions';
+import { render, settled, type TestContext } from '@ember/test-helpers';
+import { PERMISSION } from 'dummy/tests/config';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+interface LocalTestContext extends TestContext {
+  PERMISSION: typeof PERMISSION;
+}
+
+module('Integration | Helper | has-some-permissions', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders `true` or `false` based on the provided permissions', async function (this: LocalTestContext, assert) {
+    const permissionsService = this.owner.lookup(
+      'service:permissions'
+    ) as PermissionsService;
+
+    permissionsService.setPermissions([PERMISSION.FOO]);
+
+    this.PERMISSION = PERMISSION;
+
+    await render(hbs`
+      {{has-some-permissions this.PERMISSION.FOO this.PERMISSION.BAR}}
+    `);
+
+    assert.dom().hasText('true');
+
+    permissionsService.setPermissions([]);
+
+    await settled();
+
+    assert.dom().hasText('false');
+  });
+});

--- a/tests/unit/services/permissions-test.ts
+++ b/tests/unit/services/permissions-test.ts
@@ -1,3 +1,4 @@
+import { hasSomePermissions } from '@bagaar/ember-permissions';
 import type PermissionsService from '@bagaar/ember-permissions/services/permissions';
 import { type TestContext } from '@ember/test-helpers';
 import { PERMISSION, ROUTE } from 'dummy/tests/config';
@@ -82,6 +83,35 @@ module('Unit | Service | permissions', function (hooks) {
     });
   });
 
+  module('hasSomePermissions', function () {
+    test('it validates the arguments', function (this: LocalTestContext, assert) {
+      assert.throws(() => {
+        // @ts-expect-error: Testing runtime validation.
+        this.permissionsService.hasSomePermissions();
+      });
+
+      assert.throws(() => {
+        // @ts-expect-error: Testing runtime validation.
+        this.permissionsService.hasSomePermissions(null);
+      });
+    });
+
+    test('it works', function (this: LocalTestContext, assert) {
+      this.permissionsService.setPermissions([PERMISSION.FOO]);
+
+      assert.true(
+        this.permissionsService.hasSomePermissions([
+          PERMISSION.FOO,
+          PERMISSION.BAR,
+        ])
+      );
+
+      assert.false(
+        this.permissionsService.hasSomePermissions([PERMISSION.BAR])
+      );
+    });
+  });
+
   module('canAccessRoute', function () {
     test('it validates the arguments', function (this: LocalTestContext, assert) {
       assert.throws(() => {
@@ -100,30 +130,21 @@ module('Unit | Service | permissions', function (hooks) {
     });
 
     test('it works', function (this: LocalTestContext, assert) {
+      const ROUTE_FOO_ROUTE_BAR = `${ROUTE.FOO}.${ROUTE.BAR}`;
+
       this.permissionsService.setPermissions([PERMISSION.FOO]);
       this.permissionsService.setRoutePermissions({
         [ROUTE.FOO]: [PERMISSION.FOO],
+        [ROUTE_FOO_ROUTE_BAR]: hasSomePermissions([
+          PERMISSION.FOO,
+          PERMISSION.BAR,
+        ]),
         [ROUTE.BAR]: [PERMISSION.BAR],
       });
 
       assert.true(this.permissionsService.canAccessRoute(ROUTE.FOO));
+      assert.true(this.permissionsService.canAccessRoute(ROUTE_FOO_ROUTE_BAR));
       assert.false(this.permissionsService.canAccessRoute(ROUTE.BAR));
-    });
-  });
-
-  module('getRouteTreePermissions', function () {
-    test('it works', function (this: LocalTestContext, assert) {
-      const ROUTE_FOO_ROUTE_BAR = `${ROUTE.FOO}.${ROUTE.BAR}`;
-
-      this.permissionsService.setRoutePermissions({
-        [ROUTE.FOO]: [PERMISSION.FOO],
-        [ROUTE_FOO_ROUTE_BAR]: [PERMISSION.BAR],
-      });
-
-      assert.deepEqual(
-        this.permissionsService.getRouteTreePermissions(ROUTE_FOO_ROUTE_BAR),
-        [PERMISSION.FOO, PERMISSION.BAR]
-      );
     });
   });
 


### PR DESCRIPTION
- add a `hasSomePermissions` method on the `permissions` service
- add a `has-some-permissions` helper
- add `hasPermissions` and `hasSomePermissions` utils for defining can-access-route handlers